### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Build & publish release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build for ${{ matrix.target }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross & cargo-deb
+        run: |
+          cargo install cross --git https://github.com/cross-rs/cross --locked
+          cargo install cargo-deb --locked
+
+      - name: Gzip man pages
+        run: |
+          mkdir -p man
+          for f in man/*.1; do
+            [ -f "$f" ] && gzip -kf "$f"
+          done
+
+      - name: Cross compile binary
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Package tarball
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/flnk dist/
+          cp man/*.1.gz dist/ || true
+          tar -C dist -czf flnk-${{ matrix.target }}.tar.gz .
+
+      - name: Create .deb
+        run: cargo deb --target ${{ matrix.target }} --no-build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-${{ matrix.target }}
+          path: |
+            flnk-${{ matrix.target }}.tar.gz
+            target/debian/*.deb
+
+  publish:
+    name: Draft GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Create / update release from tag
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            ./artifacts/**/*.deb
+            ./artifacts/**/*.tar.gz
+          draft: false

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ An enhancement to the Unix `ln` command, providing recursive directory linking c
 
 `flnk` extends the functionality of the traditional `ln` command by enabling recursive hard linking and symlinking of entire directory structures. It's particularly useful when you need to create hard links or symbolic links for entire directory trees.
 
+## Installation
+
+Pre-built binaries and `.deb` packages for **x86_64** and **ARM64** are provided
+on the project's GitHub Releases page. Grab the archive that matches your
+platform and either extract the tarball or install the `.deb` package with
+`dpkg -i <package>.deb`.
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary
- document binary and `.deb` releases
- automate publishing tarballs and `.deb` packages for x86_64 and ARM64

## Testing
- `cargo test --workspace --all-targets --locked --no-fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_688b7c6c52ec8324904e38a0b1b1394b